### PR TITLE
replace impatient.vim with vim.loader.enable()

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -1,11 +1,4 @@
-do
-  local ok, _ = pcall(require, "impatient")
-  -- require("impatient").enable_profile() -- uncommend and use :LuaCacheProfile
-
-  if not ok then
-    vim.notify("impatient.nvim not installed", vim.log.levels.WARN)
-  end
-end
+vim.loader.enable()
 
 require("plugins")
 -- require("plugin_config")


### PR DESCRIPTION
impatient.nvim was deprecated. see the notice in [their repo](https://github.com/lewis6991/impatient.nvim):

> As of Neovim 0.9, this plugin is no longer required. Instead run:
> vim.loader.enable()

The PR for the native vim loader:
https://github.com/neovim/neovim/pull/22668